### PR TITLE
41 print builtin

### DIFF
--- a/eval/builtins.go
+++ b/eval/builtins.go
@@ -46,11 +46,23 @@ func DUMP(env Interpreter, args []object.Object) object.Object {
 func PRINT(env Interpreter, args []object.Object) object.Object {
 
 	for _, ent := range args {
-		fmt.Printf("%s", ent.String())
+		switch ent.Type() {
+		case object.NUMBER:
+			n := ent.(*object.NumberObject).Value
+			if n == float64(int(n)) {
+				fmt.Printf("%d", int(n))
+			} else {
+				fmt.Printf("%f", n)
+			}
+		case object.STRING:
+			fmt.Printf("%s", ent.(*object.StringObject).Value)
+		case object.ERROR:
+			fmt.Printf("%s", ent.(*object.ErrorObject).Value)
+		}
 	}
 
 	// Return the count of values we printed.
-	return &object.NumberObject{Value: len(args)}
+	return &object.NumberObject{Value: float64(len(args))}
 }
 
 // ABS implements ABS

--- a/eval/builtins.go
+++ b/eval/builtins.go
@@ -42,6 +42,17 @@ func DUMP(env Interpreter, args []object.Object) object.Object {
 	return &object.NumberObject{Value: 0}
 }
 
+// PRINT handles displaying strings, integers, and errors.
+func PRINT(env Interpreter, args []object.Object) object.Object {
+
+	for _, ent := range args {
+		fmt.Printf("%s", ent.String())
+	}
+
+	// Return the count of values we printed.
+	return &object.NumberObject{Value: len(args)}
+}
+
 // ABS implements ABS
 func ABS(env Interpreter, args []object.Object) object.Object {
 

--- a/eval/builtins.go
+++ b/eval/builtins.go
@@ -44,7 +44,6 @@ func DUMP(env Interpreter, args []object.Object) object.Object {
 
 // PRINT handles displaying strings, integers, and errors.
 func PRINT(env Interpreter, args []object.Object) object.Object {
-
 	for _, ent := range args {
 		switch ent.Type() {
 		case object.NUMBER:
@@ -58,6 +57,8 @@ func PRINT(env Interpreter, args []object.Object) object.Object {
 			fmt.Printf("%s", ent.(*object.StringObject).Value)
 		case object.ERROR:
 			fmt.Printf("%s", ent.(*object.ErrorObject).Value)
+		default:
+			fmt.Printf("PRINT %v", ent.String())
 		}
 	}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -589,6 +589,14 @@ func (e *Interpreter) callBuiltin(name string) object.Object {
 		//
 		tok := e.program[e.offset]
 		if tok.Type == token.COMMA {
+
+			//
+			// Hack
+			//
+			if name == "PRINT" {
+
+				args = append(args, &object.StringObject{Value: " "})
+			}
 			e.offset++
 			continue
 		}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -610,6 +610,13 @@ func (e *Interpreter) callBuiltin(name string) object.Object {
 				break
 			}
 		}
+		if tok.Type == token.COLON {
+			if n > 0 {
+				return (object.Error("Hit ':' while searching for argument %d to %s", len(args)+1, name))
+			} else {
+				break
+			}
+		}
 		if tok.Type == token.EOF {
 			if n > 0 {
 				return (object.Error("Hit EOF while searching for argument %d to %s", len(args)+1, name))

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -582,7 +582,7 @@ func (e *Interpreter) callBuiltin(name string) object.Object {
 	//
 	// Build up the args, converting and evaluating as we go.
 	//
-	for len(args) < n {
+	for n == -1 || len(args) < n {
 
 		//
 		// Get the next token, if it is a comma then eat it.
@@ -594,16 +594,29 @@ func (e *Interpreter) callBuiltin(name string) object.Object {
 		}
 
 		//
+		// If we've hit a colon, or a newline we're done.
+		//
+
+		//
 		// If we hit newline/eof then we're done.
 		//
 		// (And we've got an error, because we didn't receive as
 		// many arguments as we expected.)
 		//
 		if tok.Type == token.NEWLINE {
-			return (object.Error("Hit newline while searching for argument %d to %s", len(args)+1, name))
+			if n > 0 {
+				return (object.Error("Hit newline while searching for argument %d to %s", len(args)+1, name))
+			} else {
+				break
+			}
 		}
 		if tok.Type == token.EOF {
-			return (object.Error("Hit EOF while searching for argument %d to %s", len(args)+1, name))
+			if n > 0 {
+				return (object.Error("Hit EOF while searching for argument %d to %s", len(args)+1, name))
+			} else {
+				break
+
+			}
 		}
 
 		//

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -172,6 +172,8 @@ func New(stream *tokenizer.Tokenizer) *Interpreter {
 	t.RegisterBuiltin("TL$", 1, TL)
 	t.RegisterBuiltin("STR$", 1, STR)
 
+	// Output
+	t.RegisterBuiltin("PRINT", -1, PRINT)
 	t.RegisterBuiltin("DUMP", 1, DUMP)
 
 	return t

--- a/token/token.go
+++ b/token/token.go
@@ -38,7 +38,6 @@ const (
 	GOTO   = "GOTO"
 	INPUT  = "INPUT"
 	LET    = "LET"
-	PRINT  = "PRINT"
 	REM    = "REM"
 	RETURN = "RETURN"
 
@@ -91,7 +90,6 @@ var keywords = map[string]Type{
 	"let":    LET,
 	"next":   NEXT,
 	"or":     OR,
-	"print":  PRINT,
 	"rem":    REM,
 	"return": RETURN,
 	"step":   STEP,

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -77,8 +77,8 @@ func TestMiscTokens(t *testing.T) {
 
 // TestLineNot is a trivial test of line-number parsing.
 func TestLineNo(t *testing.T) {
-	input := `10 PRINT
-20 PRINT`
+	input := `10 REM
+20 REM`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -87,10 +87,10 @@ func TestLineNo(t *testing.T) {
 		// implicit newline which is a pain.
 		{token.NEWLINE, "\\n"},
 		{token.LINENO, "10"},
-		{token.PRINT, "PRINT"},
+		{token.REM, "REM"},
 		{token.NEWLINE, "\\n"},
 		{token.LINENO, "20"},
-		{token.PRINT, "PRINT"},
+		{token.REM, "REM"},
 		{token.NEWLINE, "\\n"},
 		{token.EOF, ""},
 	}
@@ -109,7 +109,7 @@ func TestLineNo(t *testing.T) {
 // TestStringParse tests we can cope with control-characters inside strings.
 func TestStringParse(t *testing.T) {
 	input := `10 LET a="\n\r\t\\\""
-20 PRINT`
+20 REM OK`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -124,7 +124,8 @@ func TestStringParse(t *testing.T) {
 		{token.STRING, "\n\r\t\\\""},
 		{token.NEWLINE, "\\n"},
 		{token.LINENO, "20"},
-		{token.PRINT, "PRINT"},
+		{token.REM, "REM"},
+		{token.IDENT, "OK"},
 		{token.NEWLINE, "\\n"},
 		{token.EOF, ""},
 	}
@@ -207,8 +208,8 @@ func TestComparisons(t *testing.T) {
 
 // TestNumber tests that positive and negative numbers are OK.
 func TestNumber(t *testing.T) {
-	input := `10 PRINT -4.3
-20 PRINT 5 - 3`
+	input := `10 REM -4.3
+20 REM 5 - 3`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -217,11 +218,11 @@ func TestNumber(t *testing.T) {
 		// implicit newline which is a pain.
 		{token.NEWLINE, "\\n"},
 		{token.LINENO, "10"},
-		{token.PRINT, "PRINT"},
+		{token.REM, "REM"},
 		{token.INT, "-4.3"},
 		{token.NEWLINE, "\\n"},
 		{token.LINENO, "20"},
-		{token.PRINT, "PRINT"},
+		{token.REM, "REM"},
 		{token.INT, "5"},
 		{token.MINUS, "-"},
 		{token.INT, "3"},


### PR DESCRIPTION
This pull-request moves PRINT from our core-interpreter (`eval/eval.go`) into a built-in (`eval/builtins.go`), which will close #41.

This required some changes, because registering a built-in requires that you specify the number of arguments that they will consume - and `PRINT` consumes everything up to:

* End of line.
* Or `:` (for inside an `IF` statement).

There is a regression though, which needs to be handled, print _should_ output " " when it sees a COMMA, but the commas are consumed by the argument-buildup.

I'll merge this when that is handled, even if badly.