### PR TITLE
Improve our test-cases for the builtins.

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -1,0 +1,34 @@
+// builtin_test.go - Test-cases (trivial) for our registration-glue.
+
+package builtin
+
+import "testing"
+
+//
+// Noddy test that we can set/get a value.
+//
+func TestNoddy(t *testing.T) {
+
+	// Create the holder
+	b := New()
+
+	// Register a function
+	b.Register("steve", 1, nil)
+
+	// Retrieve it.
+	n, _ := b.Get("steve")
+	if n != 1 {
+		t.Errorf("Invalid argument count for dummy entry")
+	}
+
+	//
+	// Now retrieve a missing built-in
+	//
+	foo, bar := b.Get("missing")
+	if foo != 0 {
+		t.Errorf("We found something unexpected on a missing entry!")
+	}
+	if bar != nil {
+		t.Errorf("We found something unexpected on a missing entry!")
+	}
+}

--- a/builtin/maths.go
+++ b/builtin/maths.go
@@ -204,6 +204,10 @@ func SQR(env interface{}, args []object.Object) object.Object {
 	}
 	i := args[0].(*object.NumberObject).Value
 
+	// Ensure it is valid.
+	if i < 1 {
+		return object.Error("Argument to SQR must be >0")
+	}
 	return &object.NumberObject{Value: math.Sqrt(i)}
 }
 

--- a/builtin/maths_test.go
+++ b/builtin/maths_test.go
@@ -1,0 +1,433 @@
+// maths_test.go - Simple test-cases for maths-related primitives.
+
+package builtin
+
+import (
+	"math"
+	"testing"
+
+	"github.com/skx/gobasic/object"
+)
+
+func TestABS(t *testing.T) {
+
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := ABS(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Now test that postivie and negative values work.
+	//
+	// Setup a structure for testing.
+	//
+	type ABSTest struct {
+		In  float64
+		Out float64
+	}
+
+	// Define some tests
+	tests := []ABSTest{
+		{In: 3, Out: 3},
+		{In: -3, Out: 3},
+	}
+
+	for _, test := range tests {
+
+		args := []object.Object{object.Number(test.In)}
+		output := ABS(nil, args)
+		if output.Type() != object.NUMBER {
+			t.Errorf("We expected a number-result, but got something else")
+		}
+		if output.(*object.NumberObject).Value != test.Out {
+			t.Errorf("Abs %f gave '%f' not '%f'",
+				test.In, output.(*object.NumberObject).Value, test.Out)
+		}
+	}
+}
+
+func TestACS(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := ACS(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := ACS(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+
+}
+
+func TestASN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := ASN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := ASN(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}
+
+func TestATN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := ATN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := ATN(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+
+}
+
+func TestBIN(t *testing.T) {
+
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := BIN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Test an invalid input
+	//
+	var bogus []object.Object
+	bogus = append(bogus, object.Number(2001))
+	out = BIN(nil, bogus)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected an error, but didn't receive one")
+	}
+
+	//
+	// Test a valid input
+	//
+	var valid []object.Object
+	valid = append(valid, object.Number(1001))
+	out = BIN(nil, valid)
+	if out.Type() != object.NUMBER {
+		t.Errorf("We expected no error, but got one")
+	}
+	if out.(*object.NumberObject).Value != 9 {
+		t.Errorf("Wrong result for binary conversion of 1001")
+	}
+
+}
+
+func TestCOS(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := COS(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := COS(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}
+
+func TestEXP(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := EXP(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := EXP(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}
+
+func TestINT(t *testing.T) {
+
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := INT(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Now test that truncation works
+	//
+	// Setup a structure for testing.
+	//
+	type INTTest struct {
+		In  float64
+		Out int
+	}
+
+	// Define some tests
+	tests := []INTTest{
+		{In: 3.1, Out: 3},
+		{In: -3.2, Out: -3},
+	}
+
+	for _, test := range tests {
+
+		args := []object.Object{object.Number(test.In)}
+		output := INT(nil, args)
+		if output.Type() != object.NUMBER {
+			t.Errorf("We expected a number-result, but got something else")
+		}
+		if int(output.(*object.NumberObject).Value) != test.Out {
+			t.Errorf("INT %f gave '%d' not '%d'",
+				test.In, int(output.(*object.NumberObject).Value), test.Out)
+		}
+	}
+}
+
+func TestLN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := LN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := LN(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}
+
+func TestPI(t *testing.T) {
+
+	out := PI(nil, nil)
+	if out.Type() != object.NUMBER {
+		t.Errorf("Invalid type in return value")
+	}
+	if out.(*object.NumberObject).Value != math.Pi {
+		t.Errorf("Invalid return value")
+	}
+}
+
+func TestRND(t *testing.T) {
+
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := RND(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Requires a POSITIVE argument
+	//
+	var negs []object.Object
+	negs = append(negs, object.Number(-32))
+	out = RND(nil, negs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected an error, but didn't receive one")
+	}
+
+	//
+	// Now call normally.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(32))
+	out2 := RND(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a number, but didn't receive one")
+	}
+
+}
+
+func TestSGN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := SGN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Now test that sign extension works.
+	//
+	// Setup a structure for testing.
+	//
+	type SGNTest struct {
+		In  float64
+		Out float64
+	}
+
+	// Define some tests
+	tests := []SGNTest{
+		{In: 3.1, Out: 1},
+		{In: 0, Out: 0},
+		{In: -3.2, Out: -1},
+	}
+
+	for _, test := range tests {
+
+		args := []object.Object{object.Number(test.In)}
+		output := SGN(nil, args)
+		if output.Type() != object.NUMBER {
+			t.Errorf("We expected a number-result, but got something else")
+		}
+		if output.(*object.NumberObject).Value != test.Out {
+			t.Errorf("INT %f gave '%f' not '%f'",
+				test.In, output.(*object.NumberObject).Value, test.Out)
+		}
+	}
+}
+
+func TestSIN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := SIN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := SIN(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}
+
+func TestSQR(t *testing.T) {
+
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := SQR(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Requires a POSITIVE argument
+	//
+	var negs []object.Object
+	negs = append(negs, object.Number(-32))
+	out = SQR(nil, negs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected an error, but didn't receive one")
+	}
+
+	//
+	// Now call normally.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(16))
+	out2 := SQR(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a number, but didn't receive one")
+	}
+	if out2.(*object.NumberObject).Value != 4 {
+		t.Errorf("Square-root result was wrong")
+	}
+
+}
+
+func TestTAN(t *testing.T) {
+	//
+	// Requires a number argument
+	//
+	var failArgs []object.Object
+	failArgs = append(failArgs, object.Error("Bogus type"))
+	out := TAN(nil, failArgs)
+	if out.Type() != object.ERROR {
+		t.Errorf("We expected a type-error, but didn't receive one")
+	}
+
+	//
+	// Call normally - ignore the result.  Sorry.
+	//
+	var ok []object.Object
+	ok = append(ok, object.Number(21))
+	out2 := TAN(nil, ok)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We expected a numeric-result, but didn't receive one.")
+	}
+}

--- a/builtin/misc.go
+++ b/builtin/misc.go
@@ -46,8 +46,6 @@ func PRINT(env interface{}, args []object.Object) object.Object {
 			fmt.Printf("%s", ent.(*object.StringObject).Value)
 		case object.ERROR:
 			fmt.Printf("%s", ent.(*object.ErrorObject).Value)
-		default:
-			fmt.Printf("PRINT %v", ent.String())
 		}
 	}
 

--- a/builtin/misc_test.go
+++ b/builtin/misc_test.go
@@ -1,0 +1,105 @@
+// misc_test.go - Simple test-cases for misc. primitives.
+
+package builtin
+
+import (
+	"testing"
+
+	"github.com/skx/gobasic/object"
+)
+
+func TestDump(t *testing.T) {
+
+	//
+	// Number
+	//
+	var in1 []object.Object
+	in1 = append(in1, object.Number(1))
+	out1 := DUMP(nil, in1)
+	if out1.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+
+	//
+	// String
+	//
+	var in2 []object.Object
+	in2 = append(in2, object.String("Stve"))
+	out2 := DUMP(nil, in2)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+
+	//
+	// Error
+	//
+	var in3 []object.Object
+	in3 = append(in3, object.Error("Stve"))
+	out3 := DUMP(nil, in3)
+	if out3.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+}
+
+func TestPrint(t *testing.T) {
+
+	//
+	// Number
+	//
+	var in1 []object.Object
+	in1 = append(in1, object.Number(1))
+	out1 := PRINT(nil, in1)
+	if out1.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+	if out1.(*object.NumberObject).Value != 1 {
+		t.Errorf("We didn't print one item: %f",
+			out1.(*object.NumberObject).Value)
+	}
+
+	//
+	// String
+	//
+	var in2 []object.Object
+	in2 = append(in2, object.String("Stve"))
+	out2 := PRINT(nil, in2)
+	if out2.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+	if out2.(*object.NumberObject).Value != 1 {
+		t.Errorf("We didn't print one item: %f",
+			out2.(*object.NumberObject).Value)
+	}
+
+	//
+	// Error
+	//
+	var in3 []object.Object
+	in3 = append(in3, object.Error("Stve"))
+	out3 := PRINT(nil, in3)
+	if out3.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+	if out3.(*object.NumberObject).Value != 1 {
+		t.Errorf("We didn't print one item:%f",
+			out3.(*object.NumberObject).Value)
+	}
+
+	//
+	// Now a bunch of things
+	//
+	var in4 []object.Object
+	in4 = append(in4, object.Error("Stve"))
+	in4 = append(in4, object.String("Stve"))
+	in4 = append(in4, object.Number(3))
+	in4 = append(in4, object.Number(4.3))
+	out4 := PRINT(nil, in4)
+	if out4.Type() != object.NUMBER {
+		t.Errorf("We didn't receive a number in response")
+	}
+	if out4.(*object.NumberObject).Value != 4 {
+		t.Errorf("We didn't print the expected count of items:%f",
+			out4.(*object.NumberObject).Value)
+	}
+
+}

--- a/builtin/string.go
+++ b/builtin/string.go
@@ -34,10 +34,13 @@ func CODE(env interface{}, args []object.Object) object.Object {
 	if args[0].Type() != object.STRING {
 		return object.Error("Wrong type")
 	}
-	i := args[0].(*object.StringObject).Value
+
+	// We convert this to an array of runes because we
+	// want to handle unicode strings.
+	i := []rune(args[0].(*object.StringObject).Value)
 
 	if len(i) > 0 {
-		s := i[0]
+		s := rune(i[0])
 		return &object.NumberObject{Value: float64(rune(s))}
 	}
 	return &object.NumberObject{Value: float64(0)}
@@ -51,7 +54,10 @@ func LEFT(env interface{}, args []object.Object) object.Object {
 	if args[0].Type() != object.STRING {
 		return object.Error("Wrong type")
 	}
-	in := args[0].(*object.StringObject).Value
+
+	// We convert this to an array of runes because we
+	// want to handle unicode strings.
+	in := []rune(args[0].(*object.StringObject).Value)
 
 	// Get the (float) argument.
 	if args[1].Type() != object.NUMBER {
@@ -65,7 +71,7 @@ func LEFT(env interface{}, args []object.Object) object.Object {
 
 	left := in[0:int(n)]
 
-	return &object.StringObject{Value: left}
+	return &object.StringObject{Value: string(left)}
 }
 
 // LEN returns the length of the given string
@@ -90,7 +96,10 @@ func MID(env interface{}, args []object.Object) object.Object {
 	if args[0].Type() != object.STRING {
 		return object.Error("Wrong type")
 	}
-	in := args[0].(*object.StringObject).Value
+
+	// We convert this to an array of runes because we
+	// want to handle unicode strings.
+	in := []rune(args[0].(*object.StringObject).Value)
 
 	// Get the (float) argument.
 	if args[1].Type() != object.NUMBER {
@@ -117,7 +126,7 @@ func MID(env interface{}, args []object.Object) object.Object {
 		count = float64(len(out))
 	}
 	out = out[:int(count)]
-	return &object.StringObject{Value: out}
+	return &object.StringObject{Value: string(out)}
 }
 
 // RIGHT returns the N right-most characters of the string.
@@ -127,7 +136,10 @@ func RIGHT(env interface{}, args []object.Object) object.Object {
 	if args[0].Type() != object.STRING {
 		return object.Error("Wrong type")
 	}
-	in := args[0].(*object.StringObject).Value
+
+	// We convert this to an array of runes because we
+	// want to handle unicode strings.
+	in := []rune(args[0].(*object.StringObject).Value)
 
 	// Get the (float) argument.
 	if args[1].Type() != object.NUMBER {
@@ -140,7 +152,7 @@ func RIGHT(env interface{}, args []object.Object) object.Object {
 	}
 	right := in[len(in)-int(n):]
 
-	return &object.StringObject{Value: right}
+	return &object.StringObject{Value: string(right)}
 }
 
 // STR converts a number to a string
@@ -176,12 +188,15 @@ func TL(env interface{}, args []object.Object) object.Object {
 	if args[0].Type() != object.STRING {
 		return object.Error("Wrong type")
 	}
-	in := args[0].(*object.StringObject).Value
+
+	// We convert this to an array of runes because we
+	// want to handle unicode strings.
+	in := []rune(args[0].(*object.StringObject).Value)
 
 	if len(in) > 1 {
 		rest := in[1:]
 
-		return &object.StringObject{Value: rest}
+		return &object.StringObject{Value: string(rest)}
 	}
 	return &object.StringObject{Value: ""}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -49,6 +49,11 @@ func (s *StringObject) String() string {
 	return (fmt.Sprintf("Object{Type:string, Value:%s}", s.Value))
 }
 
+// String is a helper for creating a new string-object with the given value.
+func String(val string) *StringObject {
+	return &StringObject{Value: val}
+}
+
 // NumberObject holds a number.
 type NumberObject struct {
 
@@ -64,6 +69,11 @@ func (s *NumberObject) Type() Type {
 // String returns a string representation of this object.
 func (s *NumberObject) String() string {
 	return (fmt.Sprintf("Object{Type:number, Value:%f}", s.Value))
+}
+
+// Number is a helper for creating a new number-object with the given value.
+func Number(val float64) *NumberObject {
+	return &NumberObject{Value: val}
 }
 
 // ErrorObject holds a string, which describes an error

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -62,3 +62,34 @@ func TestError(t *testing.T) {
 		t.Errorf("Wrong value for error-message")
 	}
 }
+
+func TestNumber(t *testing.T) {
+
+	a := Number(33)
+
+	// Test types
+	if a.Type() != NUMBER {
+		t.Errorf("Object has the wrong type!")
+	}
+
+	// Test values
+	if a.Value != 33 {
+		t.Errorf("Wrong value for number-object")
+	}
+
+}
+
+func TestString(t *testing.T) {
+
+	a := String("Test")
+
+	// Test types
+	if a.Type() != STRING {
+		t.Errorf("Object has the wrong type!")
+	}
+
+	// Test values
+	if a.Value != "Test" {
+		t.Errorf("Wrong value for string-object")
+	}
+}


### PR DESCRIPTION
Now that the builtin-functions have been moved to their own package they're relatively standalone.

The only dependencies they have is the "object" class.  Which means I should be able to test them __thoroughly__ without having to mess with tokens, BASIC, or similar.

This pull-request, when complete, will close #59.
