### PR TITLE
Add support for arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,18 @@ There are some (obvious) limitations:
 Arrays are used just like normal variables. They are declared using the DIM statement. Individual elements are accessed using the offsets in brackets after the variable name:
 
     10 DIM a(10,10)
-    20 LET a(1,1)=10
-    30 PRINT a(1,1)
+    20 LET a[1,1]=10
+    30 PRINT a[1,1]
 
 Arrays are indexed from 0-N, so with an array size of 10 you can access eleven
 elements:
 
      10 DIM a(10)
-     20 a(0) = 0
-     30 a(1) = 1
+     20 a[0] = 0
+     30 a[1] = 1
      40 ..
-     90 a(9) = 9
-    100 a(10) = 10
+     90 a[9] = 9
+    100 a[10] = 10
 
 ZX Spectrum BASIC indexed from 1, denying the ability to use the zeroth element, which I've long considered a mistake.
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ There are some (obvious) limitations:
 
 ### Arrays
 
-Arrays are used just like normal variables. They are declared using the DIM statement. Individual elements are accessed using the offsets in brackets after the variable name:
+Arrays are used just like normal variables, but they need to be declared using the `DIM` statement.   Individual elements are accessed using the offsets in brackets after the variable name:
 
     10 DIM a(10,10)
     20 LET a[1,1]=10
     30 PRINT a[1,1]
 
-Arrays are indexed from 0-N, so with an array size of 10 you can access eleven
+Arrays are indexed from 0-N, so with an array size of ten you can access eleven
 elements:
 
      10 DIM a(10)
@@ -91,7 +91,7 @@ elements:
      90 a[9] = 9
     100 a[10] = 10
 
-ZX Spectrum BASIC indexed from 1, denying the ability to use the zeroth element, which I've long considered a mistake.
+ZX Spectrum BASIC indexed arrays from 1, denying the ability to use the zeroth element, which I've long considered a mistake.
 
 
 ### Line Numbers

--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ Currently the following obvious primitives work:
   * Allow the use of user-defined functions [examples/25-def-fn.bas](examples/25-def-fn.bas).
 
 Most of the maths-related primitives I'm familiar with from my days
-coding on a ZX Spectrum are present, for example SIN, COS, PI, ABS.
-
-The interpreter has support for strings, and a small number of string-related
-primitives:
+coding on a ZX Spectrum are present, for example SIN, COS, PI, ABS, along
+with the similar string-related primitives:
 
 * `LEN "STEVE"`
   * Returns the length of a string "STEVE" (5)
@@ -72,12 +70,12 @@ There are some (obvious) limitations:
 * Only a single statement is allowed upon each line.
 * Only a subset of the language is implemented.
   * If there are primitives you miss [report a bug](https://github.com/skx/gobasic/issues/) and I'll add them :)
-* Only floating-point and string values are permitted, there is no support for arrays.
+* When it comes to types only floating-point and string values are permitted.
+  * There is support for arrays but only one or two dimensional ones.
 
 ### Line Numbers
 
-Line numbers are actually mostly optional, so the following program is
-valid and correct:
+Line numbers are _mostly_ optional, for examplethe following program is valid and correct:
 
      10 READ a
      20 IF a = 999 THEN GOTO 100
@@ -86,7 +84,7 @@ valid and correct:
     100 END
         DATA 1, 2, 3, 4, 999
 
-The only reason you need line-numbers is for the `GOTO` and `GOSUB` functions,
+The real reason you need line-numbers is for the `GOTO` and `GOSUB` functions,
 if you prefer to avoid them then you're welcome to do so.
 
 ### `IF` Statement
@@ -94,7 +92,7 @@ if you prefer to avoid them then you're welcome to do so.
 The handling of the IF statement is perhaps a little unusual, since I'm
 used to the BASIC provided by the ZX Spectrum which had no ELSE clause!
 
-The general form of the IF statement is:
+The general form of the IF statement I've implemented is:
 
     IF $CONDITIONAL THEN $STATEMENT1 [ELSE $STATEMENT2]
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ There are some (obvious) limitations:
 * When it comes to types only floating-point and string values are permitted.
   * There is support for arrays but only one or two dimensional ones.
 
+### Arrays
+
+Arrays are used just like normal variables. They are declared using the DIM statement. Individual elements are accessed using the offsets in brackets after the variable name:
+
+    10 DIM a(10,10)
+    20 LET a(1,1)=10
+    30 PRINT a(1,1)
+
+Arrays are indexed from 0-N, so with an array size of 10 you can access eleven
+elements:
+
+     10 DIM a(10)
+     20 a(0) = 0
+     30 a(1) = 1
+     40 ..
+     90 a(9) = 9
+    100 a(10) = 10
+
+ZX Spectrum BASIC indexed from 1, denying the ability to use the zeroth element, which I've long considered a mistake.
+
+
 ### Line Numbers
 
 Line numbers are _mostly_ optional, for examplethe following program is valid and correct:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -411,6 +411,20 @@ func (e *Interpreter) factor() object.Object {
 		case token.IDENT:
 
 			//
+			// TODO:
+			//
+			//   Handle array subscript(s)
+			//
+			//   We need to handle:
+			//
+			//     A
+			//     A[1]
+			//     A[1][2]
+			//
+			//  TODO:
+			//
+
+			//
 			// Get the contents of the variable.
 			//
 			val := e.GetVariable(tok.Literal)
@@ -1798,6 +1812,24 @@ func (e *Interpreter) runLET() error {
 	if target.Type != token.IDENT {
 		return fmt.Errorf("Expected IDENT after LET, got %v", target)
 	}
+
+	//
+	// TODO
+	//
+	// At this point we've handled
+	//   LET foo
+	//
+	// That would usually be all we needed, because we'd expect
+	//   LET foo=...
+	//
+	// However we also have to consider the case of arrays, which
+	// means we need to look for:
+	//
+	//   LET foo[1] = ..
+	//   LET bar[1][2] = ..
+	//
+	// TODO
+	//
 
 	// Now "="
 	assign := e.program[e.offset]

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1956,13 +1956,32 @@ func (e *Interpreter) RunOnce() error {
 	// Handle this token
 	//
 	switch tok.Type {
+	//
+	// Logical
+	//
 	case token.NEWLINE:
 		// NOP
 	case token.LINENO:
 		e.lineno = tok.Literal
+
+	//
+	// Actual
+	//
+	case token.BUILTIN:
+		obj := e.callBuiltin(tok.Literal)
+
+		if obj.Type() == object.ERROR {
+			return fmt.Errorf("%s", obj.(*object.ErrorObject).Value)
+		}
+
+		e.offset--
+	case token.DEF:
+		err = e.swallowLine()
 	case token.END:
 		e.finished = true
 		return nil
+	case token.DATA:
+		err = e.swallowLine()
 	case token.FOR:
 		err = e.runForLoop()
 	case token.GOSUB:
@@ -1983,21 +2002,8 @@ func (e *Interpreter) RunOnce() error {
 		err = e.swallowLine()
 	case token.RETURN:
 		err = e.runRETURN()
-	case token.DATA:
-		err = e.swallowLine()
 	case token.READ:
 		err = e.runREAD()
-	case token.DEF:
-		err = e.swallowLine()
-	case token.BUILTIN:
-
-		obj := e.callBuiltin(tok.Literal)
-
-		if obj.Type() == object.ERROR {
-			return fmt.Errorf("%s", obj.(*object.ErrorObject).Value)
-		}
-
-		e.offset--
 	default:
 		//
 		// This is either a clever piece of code, or a terrible

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -198,6 +198,60 @@ func TestDefFn(t *testing.T) {
 
 }
 
+// TestDim tests basic DIM functionality for single and 2dimensional
+// arrays
+func TestDim(t *testing.T) {
+
+	//
+	// Valid input
+	//
+	input := `10 DIM a(3)
+20 DIM b(3,3)
+`
+	tokener := tokenizer.New(input)
+	e, err := New(tokener)
+	if err != nil {
+		t.Errorf("Error parsing %s - %s", input, err.Error())
+	}
+
+	err = e.Run()
+
+	if err != nil {
+		t.Errorf("Found an unexpected error parsing valid DIM statements:%s", err.Error())
+	}
+
+	//
+	// Now we have a series of invalid DIM statements
+	// which have the wrong types
+	//
+	invalid := []string{"10 DIM 3",
+		"10 DIM 3,",
+		"10 DIM a(\"steve\"",
+		"10 DIM a(3,,,,",
+		"10 DIM a(3 (",
+		"10 DIM a(3,4,",
+		"10 DIM a(3, \"steve\")",
+		"10 DIM a(3, 4 ]",
+		"10 DIM a [",
+	}
+
+	for _, test := range invalid {
+
+		tokener := tokenizer.New(test)
+		e, err := New(tokener)
+		err = e.Run()
+
+		if err == nil {
+			t.Errorf("Expected an error parsing '%s' - Got none", test)
+		} else {
+
+			if !strings.Contains(err.Error(), "DIM") {
+				t.Errorf("Error '%s' didn't contain DIM", err.Error())
+			}
+		}
+	}
+}
+
 // TestEOF ensures that our bounds-checking of program works.
 //
 // The bounds-checks we've added have largely been as a result of
@@ -235,6 +289,12 @@ func TestEOF(t *testing.T) {
 		"10 FOR I = 1 TO 3 STEP",
 		"10 FOR I = 1 TO ",
 		"10 FOR I = 1 ",
+		"10 DIM",
+		"10 DIM x",
+		"10 DIM x(",
+		"10 DIM x(3",
+		"10 DIM x(3,",
+		"10 DIM x(3,3",
 		"10 DEF FN x() = ",
 		"10 DEF FN x()  ",
 		"10 DEF FN x( ",

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1,23 +1,5 @@
 // eval_test.go - Simple test-cases for our evaluator.
 
-//
-// TODO:
-//  Builtin
-//
-
-//
-//  Incomplete coverage:
-//    factor()
-//    term()
-//    expr()
-//    callUserFunction()
-//    callBuiltin()
-//
-//
-//    IF
-//    INPUT
-//    DEF FN
-//
 package eval
 
 import (
@@ -250,6 +232,40 @@ func TestDim(t *testing.T) {
 			}
 		}
 	}
+
+	//
+	// Now we'll test get/set of an array value
+	//
+	getSet := `
+10 DIM a(2,3)
+20 LET a[2,0]=33
+30 LET a[2,1]=2
+40 LET a[2,2]=-2
+50 LET a[2,3]=0.5
+60 LET c = a[2,0] + a[2,1] + a[2,2] + a[2,3]
+`
+
+	// Run the script
+	tokener = tokenizer.New(getSet)
+	e, err = New(tokener)
+	if err != nil {
+		t.Errorf("Error parsing %s - %s", input, err.Error())
+	}
+	err = e.Run()
+	if err != nil {
+		t.Errorf("Found an unexpected error: %s", err.Error())
+	}
+
+	// Ensure our result is expected
+	out := e.GetVariable("c")
+	if out.Type() != object.NUMBER {
+		t.Errorf("Variable 'c' had wrong type: %s", out.String())
+	}
+	res := out.(*object.NumberObject).Value
+	if res != 33.5 {
+		t.Errorf("Expected sum to be 33.5, got %f", res)
+	}
+
 }
 
 // TestEOF ensures that our bounds-checking of program works.

--- a/object/object.go
+++ b/object/object.go
@@ -58,6 +58,14 @@ func (a *ArrayObject) Type() Type {
 // Array creates a new array of the given dimensions
 func Array(x int, y int) *ArrayObject {
 
+	// Our semantics ensure that we allow "0-N".
+	if x != 0 {
+		x += 1
+	}
+	if y != 0 {
+		y += 1
+	}
+
 	// setup the sizes
 	a := &ArrayObject{X: x, Y: y}
 

--- a/object/object.go
+++ b/object/object.go
@@ -62,7 +62,12 @@ func Array(x int, y int) *ArrayObject {
 	a := &ArrayObject{X: x, Y: y}
 
 	// for each entry ensure we store a value.
-	c := x * y
+	var c int
+	if x == 0 {
+		c = y
+	} else {
+		c = x * y
+	}
 
 	// we default to "0"
 	for c > 0 {
@@ -76,7 +81,10 @@ func Array(x int, y int) *ArrayObject {
 // Get the value at the given X,Y coordinate
 func (a *ArrayObject) Get(x int, y int) Object {
 	offset := x*a.X + y
-	if offset > a.X*a.Y {
+	if a.X == 0 && offset > a.Y {
+		return &ErrorObject{Value: "Array access out of bounds!"}
+	}
+	if (a.X != 0) && (offset > a.X*a.Y) {
 		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
 
@@ -84,14 +92,17 @@ func (a *ArrayObject) Get(x int, y int) Object {
 }
 
 // Set the value at the given X,Y coordinate
-func (a *ArrayObject) Set(x int, y int, obj Object) error {
+func (a *ArrayObject) Set(x int, y int, obj Object) Object {
 	offset := x*a.X + y
 
-	if offset > a.X*a.Y {
-		return fmt.Errorf("Array access out of bounds")
+	if a.X == 0 && offset > a.Y {
+		return &ErrorObject{Value: "Array access out of bounds!"}
+	}
+	if (a.X != 0) && (offset > a.X*a.Y) {
+		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
 	a.Contents[offset] = obj
-	return nil
+	return obj
 }
 
 // String returns the string-contents of the string

--- a/object/object.go
+++ b/object/object.go
@@ -78,7 +78,7 @@ func Array(x int, y int) *ArrayObject {
 	}
 
 	// we default to "0"
-	for c > 0 {
+	for c >= 0 {
 		a.Contents = append(a.Contents, Number(0))
 		c--
 	}
@@ -91,12 +91,14 @@ func (a *ArrayObject) Get(x int, y int) Object {
 	offset := x*a.X + y
 
 	if a.X == 0 && offset >= a.Y {
-		return &ErrorObject{Value: "Array access out of bounds!"}
+		return &ErrorObject{Value: "Get-Array access out of bounds (Y)"}
 	}
-	if (a.X != 0) && (offset >= a.X*a.Y) {
-		return &ErrorObject{Value: "Array access out of bounds!"}
+	if (a.X != 0) && (offset > a.X*a.Y) {
+		return &ErrorObject{Value: "Get-Array access out of bounds (X,Y)"}
 	}
-
+	if offset > len(a.Contents) {
+		return &ErrorObject{Value: "Get-Array access out of bounds (LEN)"}
+	}
 	return (a.Contents[offset])
 }
 
@@ -105,11 +107,15 @@ func (a *ArrayObject) Set(x int, y int, obj Object) Object {
 	offset := x*a.X + y
 
 	if a.X == 0 && offset >= a.Y {
-		return &ErrorObject{Value: "Array access out of bounds!"}
+		return &ErrorObject{Value: "Set-Array access out of bounds (Y)"}
 	}
-	if (a.X != 0) && (offset >= a.X*a.Y) {
-		return &ErrorObject{Value: "Array access out of bounds!"}
+	if (a.X != 0) && (offset > a.X*a.Y) {
+		return &ErrorObject{Value: "Set-Array access out of bounds (X,Y)"}
 	}
+	if offset > len(a.Contents) {
+		return &ErrorObject{Value: "Set-Array access out of bounds (LEN)"}
+	}
+
 	a.Contents[offset] = obj
 	return obj
 }

--- a/object/object.go
+++ b/object/object.go
@@ -89,10 +89,11 @@ func Array(x int, y int) *ArrayObject {
 // Get the value at the given X,Y coordinate
 func (a *ArrayObject) Get(x int, y int) Object {
 	offset := x*a.X + y
-	if a.X == 0 && offset > a.Y {
+
+	if a.X == 0 && offset >= a.Y {
 		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
-	if (a.X != 0) && (offset > a.X*a.Y) {
+	if (a.X != 0) && (offset >= a.X*a.Y) {
 		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
 
@@ -103,10 +104,10 @@ func (a *ArrayObject) Get(x int, y int) Object {
 func (a *ArrayObject) Set(x int, y int, obj Object) Object {
 	offset := x*a.X + y
 
-	if a.X == 0 && offset > a.Y {
+	if a.X == 0 && offset >= a.Y {
 		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
-	if (a.X != 0) && (offset > a.X*a.Y) {
+	if (a.X != 0) && (offset >= a.X*a.Y) {
 		return &ErrorObject{Value: "Array access out of bounds!"}
 	}
 	a.Contents[offset] = obj

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -98,7 +97,6 @@ func TestString(t *testing.T) {
 func TestArray(t *testing.T) {
 
 	// Create an array
-	fmt.Printf("Creating array\n")
 	a := Array(5, 5)
 
 	if a.Type() != ARRAY {
@@ -145,7 +143,7 @@ func TestArray(t *testing.T) {
 		t.Errorf("Expected error - got none!")
 	}
 	e = a.Set(3, 2, Number(3))
-	if e != nil {
-		t.Errorf("We didn't expect an error, but we found one")
+	if e.Type() == ERROR {
+		t.Errorf("We didn't expect an error, but we found one: %v", e)
 	}
 }

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -91,5 +92,60 @@ func TestString(t *testing.T) {
 	// Test values
 	if a.Value != "Test" {
 		t.Errorf("Wrong value for string-object")
+	}
+}
+
+func TestArray(t *testing.T) {
+
+	// Create an array
+	fmt.Printf("Creating array\n")
+	a := Array(5, 5)
+
+	if a.Type() != ARRAY {
+		t.Errorf("Object has the wrong type!")
+	}
+
+	// Ensure each dimension is gettable
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			a.Set(i, j, Number(float64(i*j)))
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			expected := float64(i * j)
+
+			actual := a.Get(i, j)
+
+			if actual.Type() != NUMBER {
+				t.Errorf("Failed to get the correct type")
+			}
+			if expected != actual.(*NumberObject).Value {
+				t.Errorf("Failed to get the right value for %d,%d!", i, j)
+			}
+		}
+	}
+
+	// Convert the object to a string
+	out := a.String()
+	if !strings.Contains(out, "Value:16.00") {
+		t.Errorf("Failed to find a decent value in our string-representation")
+	}
+
+	// Get an out of bounds entry
+	err := a.Get(6, 4)
+	if err.Type() != ERROR {
+		t.Errorf("Expected error - got none!")
+	}
+
+	// Set an out of bounds entry
+	e := a.Set(6, 4, Number(3))
+	if e == nil {
+		t.Errorf("Expected error - got none!")
+	}
+	e = a.Set(3, 2, Number(3))
+	if e != nil {
+		t.Errorf("We didn't expect an error, but we found one")
 	}
 }

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -94,7 +94,48 @@ func TestString(t *testing.T) {
 	}
 }
 
-func TestArray(t *testing.T) {
+func Test1DArray(t *testing.T) {
+
+	// Create an array of one dimension
+	a := Array(0, 5)
+
+	if a.Type() != ARRAY {
+		t.Errorf("Object has the wrong type!")
+	}
+
+	// Ensure each dimension is settable
+	for i := 0; i < 5; i++ {
+		a.Set(0, i, Number(float64(i)))
+	}
+
+	// Ensure each dimension is gettable
+	sum := 0
+	for i := 0; i < 5; i++ {
+		out := a.Get(0, i)
+
+		if out.Type() == NUMBER {
+			sum += int(out.(*NumberObject).Value)
+		}
+	}
+
+	if sum != 10 {
+		t.Errorf("Sum was %d not %d", sum, 10)
+	}
+
+	// Test that we have bound-checking on Get
+	err1 := a.Get(0, 6)
+	if err1.Type() != ERROR {
+		t.Errorf("Expected a bounds-error, got none")
+	}
+
+	// Test that we have bound-checking on Set
+	err2 := a.Set(0, 6, err1)
+	if err2.Type() != ERROR {
+		t.Errorf("Expected a bounds-error, got none")
+	}
+}
+
+func Test2DArray(t *testing.T) {
 
 	// Create an array
 	a := Array(5, 5)

--- a/token/token.go
+++ b/token/token.go
@@ -59,6 +59,7 @@ const (
 
 	// Misc
 	DATA = "DATA"
+	DIM  = "DIM"
 	DEF  = "DEF"
 	FN   = "FN"
 	READ = "READ"
@@ -77,6 +78,8 @@ const (
 	SEMICOLON = ";"
 	LBRACKET  = "("
 	RBRACKET  = ")"
+	LINDEX    = "["
+	RINDEX    = "]"
 
 	// Comparison functions.
 	GT        = ">"
@@ -90,6 +93,7 @@ const (
 var keywords = map[string]Type{
 	"and":    AND,
 	"data":   DATA,
+	"dim":    DIM,
 	"def":    DEF,
 	"else":   ELSE,
 	"end":    END,

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -104,6 +104,10 @@ func (l *Tokenizer) NextToken() token.Token {
 		tok = newToken(token.LBRACKET, l.ch)
 	case rune(')'):
 		tok = newToken(token.RBRACKET, l.ch)
+	case rune('['):
+		tok = newToken(token.LINDEX, l.ch)
+	case rune(']'):
+		tok = newToken(token.RINDEX, l.ch)
 	case rune('<'):
 		if l.peekChar() == rune('>') {
 			ch := l.ch

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -36,7 +36,7 @@ func TestMathOperators(t *testing.T) {
 
 // TestMiscTokens just tests the tokens we've not otherwise covered.
 func TestMiscTokens(t *testing.T) {
-	input := `(),:;`
+	input := `()][,:;`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -44,6 +44,8 @@ func TestMiscTokens(t *testing.T) {
 	}{
 		{token.LBRACKET, "("},
 		{token.RBRACKET, ")"},
+		{token.RINDEX, "]"},
+		{token.LINDEX, "["},
 		{token.COMMA, ","},
 		{token.COLON, ":"},
 		{token.SEMICOLON, ";"},


### PR DESCRIPTION
This pull request will close #75, when complete.

In brief:

* We've updated `object/object.go` to support an array-type.
* We've added `dim` as a keyword
* We've added tokens for index-operations `[` + `]`.
* We've updated get/set to handle array-indexes as well as raw-variables.

The initial four commits were erroneously made on `master`, and have been pushed to this new branch, which means we lost the history, which is a shame.