### PR TITLE
Report errors on bare idents

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -2284,7 +2284,7 @@ func (e *Interpreter) RunOnce() error {
 	case token.READ:
 		err = e.runREAD()
 	case token.IDENT:
-		err = fmt.Errorf("Invalid statement %v", tok)
+		err = fmt.Errorf("Unexpected identifier %v", tok)
 	default:
 		//
 		// This is either a clever piece of code, or a terrible

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -2283,6 +2283,8 @@ func (e *Interpreter) RunOnce() error {
 		err = e.runRETURN()
 	case token.READ:
 		err = e.runREAD()
+	case token.IDENT:
+		err = fmt.Errorf("Invalid statement %v", tok)
 	default:
 		//
 		// This is either a clever piece of code, or a terrible

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1489,6 +1489,39 @@ func TestTrace(t *testing.T) {
 
 }
 
+// TestRawIdent tests that we handle bogus statements correctly.
+// NOTE: If/when we support LET being optional this test-case will fail.
+func TestRawIdent(t *testing.T) {
+
+	//
+	// Programs that are bogus
+	//
+	tests := []string{
+		"10 A = 3",
+		"10 A * B",
+	}
+
+	//
+	// Run each one
+	//
+	for _, test := range tests {
+
+		tokener := tokenizer.New(test)
+		e, err := New(tokener)
+		if err != nil {
+			t.Errorf("Error parsing %s - %s", test, err.Error())
+		}
+
+		err = e.Run()
+		if err == nil {
+			t.Errorf("Expected an error - found none in %s", test)
+		}
+		if !strings.Contains(err.Error(), "Unexpected identifier") {
+			t.Errorf("Got an error, but it was the wrong one: %s", err.Error())
+		}
+	}
+}
+
 // TestVariables gets/sets some variables and ensures they work
 func TestVariables(t *testing.T) {
 


### PR DESCRIPTION
This pull-request makes an error of identifiers as tokens:

    10 A = 3
    20 A = B

This closes #86.

Note that this doesn't catch:

    10 IF 1 < 3 THEN a = 3

Since that program is rewritten at load-time, to be:

    10 IF 1 < 3 THEN LET a = 3
