### PR TITLE
Support SWAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The following obvious primitives work as you'd expect:
 * `READ` & `DATA`
   * Allow reading from stored data within the program.
   * See [examples/35-read-data.bas](examples/35-read-data.bas) for a demonstration.
+* `SWAP`
+  * Allow swapping the contents of two variables.
+  * Useful for sorting arrays.
 * `DEF FN` & `FN`
   * Allow user-defined functions to be defined or invoked.
   * See [examples/25-def-fn.bas](examples/25-def-fn.bas) for an example.

--- a/token/token.go
+++ b/token/token.go
@@ -58,11 +58,12 @@ const (
 	XOR = "XOR"
 
 	// Misc
-	DATA = "DATA"
-	DIM  = "DIM"
 	DEF  = "DEF"
+	DIM  = "DIM"
 	FN   = "FN"
 	READ = "READ"
+	SWAP = "SWAP"
+	DATA = "DATA"
 
 	// Woo-operators
 	ASSIGN   = "=" // LET x = 3
@@ -110,6 +111,7 @@ var keywords = map[string]Type{
 	"rem":    REM,
 	"return": RETURN,
 	"step":   STEP,
+	"swap":   SWAP,
 	"then":   THEN,
 	"to":     TO,
 	"xor":    XOR,


### PR DESCRIPTION
This pull-request will implement support for the SWAP primitive, and will close #90 once merged.

Sample usage:

       10 LET a = 3
       20 LET b = 41
       30 PRINT "A:" , a, " B:", b, "\n"
       40 SWAP a,b
       50 PRINT "A:" , a, " B:", b, "\n"
       60 PRINT "\n"

       100 DIM a(10)
       110 a[2] = 33
       120 PRINT "a[2]:", a[2], " a[3]", a[3], "\n"
       130 SWAP a[2], a[3]
       140 PRINT "a[2]:", a[2], " a[3]", a[3], "\n"
       150 PRINT "\n"

       1000 DIM a(3)
       1010 LET a[1] = "steve"
       1020 LET a[2] = "kemp"
       1030 PRINT a[1], " ", a[2], "\n"
       2000 SWAP a[1], a[2]
       2010 PRINT a[1], " ", a[2], "\n"
       2020 PRINT "\n"

Once implemented this is the expected outcome:

       frodo ~/go/src/github.com/skx/gobasic $ ./gobasic swap.bas 
       A: 3  B: 41 
       A: 41  B: 3 

       a[2]: 33  a[3] 0 
       a[2]: 0  a[3] 33 

       steve   kemp 
       kemp   steve 

