### PR TITLE
Allow caller to specify a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ defer cancel()
 t := tokenizer.New(string(`10 GOTO 10`))
 
 // Ensure we pass the context over
-e, err := eval.NewWithContext(t, ctx)
+e, err := eval.NewWithContext(ctx,t)
 if err != nil {
    fmt.Printf("error creating interpreter: %s\n", err.Error())
    panic(err)   // proper handling here

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * [50 PRINT "Implementation"](#50-print-implementation)
 * [60 PRINT "Sample Code"](#60-print-sample-code)
 * [70 PRINT "Embedding"](#70-print-embedding)
+* [75 PRINT "DoS"](#75-print-dos)
 * [80 PRINT "Visual BASIC!"](#80-print-visual-basic)
 * [90 PRINT "Bugs?"](#90-print-bugs)
 * [100 PRINT "Project Goals / Links"](#100-print-project-goals--links)
@@ -361,6 +362,52 @@ in the standalone interpreter.)
 <br />
 <br />
 <br />
+
+
+
+## 75 PRINT "DoS"
+
+When it comes to security problems the most obvious issue we might suffer from is denial-of-service attacks; it is certainly possible for this library to be given faulty programs, for example invalid syntax, or references to undefined functions.   Failures such as those would be detected at parse/run time, as appropriate.
+
+In short running user-supplied scripts should be safe, but there is one obvious exception, the following program is valid:
+
+```
+10 PRINT "STEVE ROCKS!"
+20 GOTO 10
+```
+
+This program will __never__ terminate!  If you're handling untrusted user-scripts, you'll want to ensure that you explicitly setup a timeout period.
+
+The following will do what you expect:
+
+```
+// Setup a timeout period of five seconds
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+// Now create the interpreter, via the tokenizer
+t := tokenizer.New(string(`10 GOTO 10`))
+
+// Ensure we pass the context over
+e, err := eval.NewWithContext(t, ctx)
+if err != nil {
+   fmt.Printf("error creating interpreter: %s\n", err.Error())
+   panic(err)   // proper handling here
+}
+
+// Now run the program
+err = e.Run()
+if err != nil {
+  fmt.Printf("error running: %s\n", err.Error())
+  panic(err)   // proper handling here
+}
+
+// Here we'll see a timeout eror
+
+```
+
+The program will be terminated with an error after five seconds, which means that your host application will continue to run rather than being blocked forever!
+
 
 
 ## 80 PRINT "Visual BASIC!"

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -428,7 +428,7 @@ func New(stream *tokenizer.Tokenizer) (*Interpreter, error) {
 // NewWithContext is a constructor which allows a context to be specified.
 //
 // It will defer to New for the basic constructor behaviour.
-func NewWithContext(stream *tokenizer.Tokenizer, ctx context.Context) (*Interpreter, error) {
+func NewWithContext(ctx context.Context, stream *tokenizer.Tokenizer) (*Interpreter, error) {
 
 	// Create
 	i, err := New(stream)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -15,6 +15,7 @@ package eval
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -111,6 +112,9 @@ type Interpreter struct {
 
 	// fns contains a map of user-defined functions.
 	fns map[string]userFunction
+
+	// context for handling timeout
+	context context.Context
 }
 
 // StdInput allows access to the input-reading object.
@@ -184,6 +188,11 @@ func New(stream *tokenizer.Tokenizer) (*Interpreter, error) {
 	// Setup a map to hold user-defined functions.
 	//
 	t.fns = make(map[string]userFunction)
+
+	//
+	// No context by default
+	//
+	t.context = context.Background()
 
 	//
 	// The previous token we've seen, if any.
@@ -414,6 +423,22 @@ func New(stream *tokenizer.Tokenizer) (*Interpreter, error) {
 	// Return our configured interpreter
 	//
 	return t, nil
+}
+
+// NewWithContext is a constructor which allows a context to be specified.
+//
+// It will defer to New for the basic constructor behaviour.
+func NewWithContext(stream *tokenizer.Tokenizer, ctx context.Context) (*Interpreter, error) {
+
+	// Create
+	i, err := New(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	i.context = ctx
+
+	return i, nil
 }
 
 // FromString is a constructor which takes a string, and constructs
@@ -2606,6 +2631,20 @@ func (e *Interpreter) Run() error {
 	// We walk our series of tokens.
 	//
 	for e.offset < len(e.program) && !e.finished {
+
+		//
+		// We've been given a context, which we'll test at every
+		// iteration of our main-loop.
+		//
+		// This is a little slow and inefficient, but we need
+		// to allow our execution to be time-limited.
+		//
+		select {
+		case <-e.context.Done():
+			return fmt.Errorf("timeout during execution")
+		default:
+			// nop
+		}
 
 		err := e.RunOnce()
 


### PR DESCRIPTION
This allows hosts which embed `gobasic` as a scripting-language
to both avoid and detect infinite loops.

This closes #116.